### PR TITLE
chore: Sync with repo-template-go

### DIFF
--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -38,17 +38,19 @@ jobs:
           - "1.21"
           - "1.22"
           - "1.23"
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: unit tests
-        run: |
-          make go-test
+        run: make go-test
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a # v5.0.2
         with:
@@ -102,8 +104,17 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: "package.json"
-      - run: |
-          make format
+      # NOTE: Install Go 1.23 since gofumpt and gci need Go >1.22.
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: "1.23"
+      - run: go install mvdan.cc/gofumpt@v0.7.0
+      - run: go install github.com/daixiang0/gci@v0.13.5
+      # NOTE: Now install the Go version required by go.mod.
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: "go.mod"
+      - run: make format
       - name: check diff
         run: |
           set -euo pipefail
@@ -168,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: "go.mod"
       - env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,12 +36,16 @@ linters:
   enable:
     - asciicheck
     - contextcheck
+    # NOTE: copyloopvar is disabled because we support Go 1.20.
+    # - copyloopvar
     - depguard
     - dogsled
     - err113
     - errcheck
     - errorlint
     - exhaustive
+    # NOTE: exportloopref is deprecated but included because the library
+    #       supports Go 1.20.
     - exportloopref
     - gci
     - gochecknoinits

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ REPO_NAME = $(shell basename "$$(pwd)")
 # Groups can be added with the following style:
 #
 #	## Group name
-.PHONY: help
 help: ## Shows all targets and help from the Makefile (this message).
 	@echo "$(REPO_NAME) Makefile"
 	@echo "Usage: make [COMMAND]"
@@ -117,7 +116,7 @@ license-headers: ## Update license headers.
 		fi;
 
 .PHONY: format
-format: md-format yaml-format ## Format all files
+format: go-format md-format yaml-format ## Format all files
 
 .PHONY: md-format
 md-format: node_modules/.installed ## Format Markdown files.
@@ -151,6 +150,7 @@ go-format: ## Format Go files (gofumpt).
 ## Linters
 #####################################################################
 
+.PHONY: lint
 lint: golangci-lint yamllint actionlint markdownlint ## Run all linters.
 
 .PHONY: actionlint


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Sync with repo-template-go latest version.

Squashed commit of the following:

commit 91c7ae113962411e23439ea28063c52a0fec78f6
Author: Ian Lewis <ian@ianlewis.org>
Date:   Wed Feb 5 15:32:24 2025 +0900

    fix(doc): test badge (#7)

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

commit 7bff21b29078ec5f5fbe96ef20f6af95de3c50a7
Author: Ian Lewis <ian@ianlewis.org>
Date:   Wed Feb 5 15:28:11 2025 +0900

    Sync w/ upstream (#6)

    * fix: todo-issue-reopener permissions (#87)

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

    * chore: use Node.js 22 LTS (#88)

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

    * docs: Add docs on syncing (#90)

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

    ---------

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

commit b3f0e92b2eaa1174696f39896f48de03fcd84bbd
Author: Ian Lewis <ian@ianlewis.org>
Date:   Wed Feb 5 15:02:32 2025 +0900

    ci: Add unit-tests pre-submit (#4)

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

commit ab2b9ad30115d9cac6935b39139aa26b05714419
Author: Ian Lewis <ian@ianlewis.org>
Date:   Wed Feb 5 14:47:48 2025 +0900

    fix: make format now runs gofumpt (#2)

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

commit 379e06ed4b69871a8e7353075de221d649cc12e6
Author: Ian Lewis <ian@ianlewis.org>
Date:   Tue Feb 4 02:56:08 2025 +0000

    feat: Add Go related files

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

commit 9ceb4b71d709fc576067217b33eca00dacbe4472
Author: Ian Lewis <ian@ianlewis.org>
Date:   Tue Feb 4 10:55:59 2025 +0900

    docs: Add link to repo-template-go (#84)

    Signed-off-by: Ian Lewis <ian@ianlewis.org>

commit 09eda8c6e8e4468599d11d0d40ea85cba6388da2
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Feb 3 12:01:36 2025 +0900

    chore(deps-dev): Bump markdownlint-cli from 0.43.0 to 0.44.0 (#80)

    Bumps [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) from 0.43.0 to 0.44.0.
    - [Release notes](https://github.com/igorshubovych/markdownlint-cli/releases)
    - [Commits](https://github.com/igorshubovych/markdownlint-cli/compare/v0.43.0...v0.44.0)

    ---
    updated-dependencies:
    - dependency-name: markdownlint-cli dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 8dba6ff84e1a4173a7d6b61f156ab419e151b667
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Feb 3 11:59:39 2025 +0900

    chore(deps): Bump actions/stale from 9.0.0 to 9.1.0 (#79)

    Bumps [actions/stale](https://github.com/actions/stale) from 9.0.0 to 9.1.0.
    - [Release notes](https://github.com/actions/stale/releases)
    - [Changelog](https://github.com/actions/stale/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/actions/stale/compare/28ca1036281a5e5922ead5184a1bbf96e5fc984e...5bef64f19d7facfb25b37b414482c7164d639639)

    ---
    updated-dependencies:
    - dependency-name: actions/stale dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 5fc52385eb92bdd48a8c93d4ff1ba8a4e953bf16
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Feb 3 11:59:29 2025 +0900

    chore(deps): Bump actions/setup-node from 4.1.0 to 4.2.0 (#78)

    Bumps [actions/setup-node](https://github.com/actions/setup-node) from 4.1.0 to 4.2.0.
    - [Release notes](https://github.com/actions/setup-node/releases)
    - [Commits](https://github.com/actions/setup-node/compare/39370e3970a6d050c480ffad4ff0ed4d3fdee5af...1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a)

    ---
    updated-dependencies:
    - dependency-name: actions/setup-node dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 2603dc771408ec5008573a2762aab7f14e0a91ed
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Feb 3 11:59:17 2025 +0900

    chore(deps-dev): Bump node from 23.5.0 to 23.7.0 (#81)

    Bumps [node](https://github.com/aredridel/node-bin-gen) from 23.5.0 to 23.7.0.
    - [Commits](https://github.com/aredridel/node-bin-gen/commits)

    ---
    updated-dependencies:
    - dependency-name: node dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 6f7999d914c9a490fc4a9dc85d10c5e2592f55c0
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri Jan 3 12:29:30 2025 +0900

    chore(deps-dev): Bump node from 23.3.0 to 23.5.0 (#74)

    Bumps [node](https://github.com/aredridel/node-bin-gen) from 23.3.0 to 23.5.0.
    - [Commits](https://github.com/aredridel/node-bin-gen/commits)

    ---
    updated-dependencies:
    - dependency-name: node dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 2efdb250c4f15cb60cccf4570dbd3828ce441b18
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri Jan 3 12:27:34 2025 +0900

    chore(deps-dev): Bump prettier from 3.4.1 to 3.4.2 (#75)

    Bumps [prettier](https://github.com/prettier/prettier) from 3.4.1 to 3.4.2.
    - [Release notes](https://github.com/prettier/prettier/releases)
    - [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/prettier/prettier/compare/3.4.1...3.4.2)

    ---
    updated-dependencies:
    - dependency-name: prettier dependency-type: direct:development update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 8f766d011197d274de7e3a8618d260f99b34a615
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Fri Jan 3 12:26:05 2025 +0900

    fix: pyyaml hash (#76)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 233241f3fe4e62caba065dae85139fbb4df40055
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Fri Jan 3 03:24:10 2025 +0000

    fix: pyyaml hash

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 798e595a21c930206a713c653d389e7806a4f6fd
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed Jan 1 15:05:12 2025 +0900

    chore(deps-dev): Bump prettier from 3.3.3 to 3.4.1 (#73)

    Bumps [prettier](https://github.com/prettier/prettier) from 3.3.3 to 3.4.1.
    - [Release notes](https://github.com/prettier/prettier/releases)
    - [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/prettier/prettier/compare/3.3.3...3.4.1)

    ---
    updated-dependencies:
    - dependency-name: prettier dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 01ca461d3244286272df47f479d344db27e6defe
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 16:48:00 2024 +0900

    docs: Add note about dependencies (#72)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit e567deb265ff220428487ebe15175d007f290832
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 16:39:23 2024 +0900

    feat: Install yamllint in venv (#71)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 1ef8965a936d6cdafd38b0a8e2ffacd069729382
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 14:49:05 2024 +0900

    ci: Add formatting pre-submit (#70)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 745c1ff340fbe08b4082a045b808b0e3d055bb72
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 14:39:37 2024 +0900

    docs: fix link to shellcheck (#69)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit f630e371c092a4712cc37a57a9f27d348554e9fe
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 14:20:53 2024 +0900

    docs: Add note about shellcheck (#66)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit ca627a11b98595c1dd34961925136a4688fea1a3
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 13:49:52 2024 +0900

    chore: update headers (#65)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 9200f28fdded4cab19248081e1b0e2c76a917106
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Nov 26 13:44:20 2024 +0900

    chore(deps-dev): Bump markdownlint-cli from 0.42.0 to 0.43.0 (#60)

    Bumps [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) from 0.42.0 to 0.43.0.
    - [Release notes](https://github.com/igorshubovych/markdownlint-cli/releases)
    - [Commits](https://github.com/igorshubovych/markdownlint-cli/compare/v0.42.0...v0.43.0)

    ---
    updated-dependencies:
    - dependency-name: markdownlint-cli dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 66d37d35d1cac3b3873faa9dcc6a7b3b87b3e9b6
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Nov 26 13:41:40 2024 +0900

    chore(deps-dev): Bump node from 22.11.0 to 23.3.0 (#61)

    Bumps [node](https://github.com/aredridel/node-bin-gen) from 22.11.0 to 23.3.0.
    - [Commits](https://github.com/aredridel/node-bin-gen/commits)

    ---
    updated-dependencies:
    - dependency-name: node dependency-type: direct:development update-type: version-update:semver-major ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 1bf67d825b38c73abb99b857c0991d013ad193d7
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 13:35:44 2024 +0900

    fix: Remove gomod dependabot config (#58)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 4ddd77f3b16adffd2fccf2bdc631d62d73d2ac2d
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 13:32:38 2024 +0900

    feat: Add CHANGELOG (#57)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit dd61e7bb9e4dd34b912ccebf83a9ff5314944d1d
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 13:14:04 2024 +0900

    feat: Add issue and PR templates (#56)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 38a3ffca4070445a4197479476ce1c54711daf29
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 12:32:04 2024 +0900

    docs: update readme (#51)

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 2a188a3e7a803d43d2b94031275172e73379c43c
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Tue Nov 26 03:16:26 2024 +0000

    docs: update README

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 8d35ba8f4c026978d0e582df0be51d08b65e2210
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Tue Nov 26 03:09:18 2024 +0000

    docs: repository documentation

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 9fd15f02cc4d4226138f0133655cd230982ec884
Merge: 0f94075 887f7ae
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 11:53:58 2024 +0900

    Merge pull request #47 from ianlewis/25-dont-format-files-in-git-submodules

    fix: don't format files in submodules

commit 887f7ae1c445f26f4896365e3796790a0b367dba
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Tue Nov 26 02:53:03 2024 +0000

    fix: don't format files in submodules

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 0f9407550b3e4f859ab99fe04ace4e53ab54fd1d
Merge: 6f3c950 f1a3a16
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 11:47:44 2024 +0900

    Merge pull request #40 from ianlewis/dependabot/github_actions/ianlewis/todo-issue-reopener-1.4.0

    Bump ianlewis/todo-issue-reopener from 1.3.0 to 1.4.0

commit 6f3c9504de03e19dc6ec543c3aefc88ff44abd17
Merge: 3342af8 5e2a486
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 11:47:36 2024 +0900

    Merge pull request #41 from ianlewis/dependabot/github_actions/actions/checkout-4.2.2

    Bump actions/checkout from 4.2.0 to 4.2.2

commit 3342af8284b2b4b6a205060a32d71f96025badd2
Merge: afcbb9b 977750d
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Tue Nov 26 11:47:22 2024 +0900

    Merge pull request #46 from ianlewis/yamllintignore

    feat: use .gitignore for yamllint

commit 977750dad70b2429d714468fffb2fe0ca0fff8e2
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Tue Nov 26 02:45:42 2024 +0000

    fix: config

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 3dc86189638cfdb185f7f9838ace0dddc78534eb
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Tue Nov 26 02:34:39 2024 +0000

    feat: use .gitignore for yamllint

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 5e2a486052213e261d7e17270f036b3dd6c00f26
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sun Nov 17 16:22:19 2024 +0000

    Bump actions/checkout from 4.2.0 to 4.2.2

    Bumps [actions/checkout](https://github.com/actions/checkout) from 4.2.0 to 4.2.2.
    - [Release notes](https://github.com/actions/checkout/releases)
    - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/actions/checkout/compare/d632683dd7b4114ad314bca15554477dd762a938...11bd71901bbe5b1630ceea73d27597364c9af683)

    ---
    updated-dependencies:
    - dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit afcbb9bfdc25c82036288ef440db3342e377af91
Merge: 7003874 54f6164
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Mon Nov 18 01:21:26 2024 +0900

    Merge pull request #45 from ianlewis/43-use-user-copyright-in-autogen-make-target

    update license header tool

commit 54f61641f328bbf03809aba2353e1f41b40ee715
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Sun Nov 17 16:20:10 2024 +0000

    update license header tool

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 700387475ef72b2efbd363c65c1244af1c323861
Merge: 35ac44c 7b3fccb
Author: Ian Lewis <IanMLewis@gmail.com>
Date:   Sun Nov 17 23:23:44 2024 +0900

    Merge pull request #42 from ianlewis/26-dont-run-linters-on-git-submodules

    fix: Don't run linters on git submodules

commit 7b3fccb55151dbdc235f45457ab0fbaecdd0d8da
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Sun Nov 17 14:22:04 2024 +0000

    fix: Don't run linters on git submodules

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit f1a3a160cf50eaba6deb151657b53d17b25aaf48
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri Nov 1 16:14:30 2024 +0000

    Bump ianlewis/todo-issue-reopener from 1.3.0 to 1.4.0

    Bumps [ianlewis/todo-issue-reopener](https://github.com/ianlewis/todo-issue-reopener) from 1.3.0 to 1.4.0.
    - [Release notes](https://github.com/ianlewis/todo-issue-reopener/releases)
    - [Changelog](https://github.com/ianlewis/todo-issue-reopener/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/ianlewis/todo-issue-reopener/compare/9adf81abbaeceed8d6c90c106cc2a965797963cf...1a99cfd93fb95eb4f212a1ebaf3e9ef8ba4c46f8)

    ---
    updated-dependencies:
    - dependency-name: ianlewis/todo-issue-reopener dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 35ac44c027bc87399248e7fc1eab364b8112da86
Merge: f332076 80730df
Author: Ian Lewis <ianlewis@google.com>
Date:   Thu Oct 31 18:38:25 2024 +0900

    Merge pull request #39 from ianlewis/38-update-actionlint-to-fix-concurrent-map-writes-error

    chore(ci): update actionlint

commit 80730df165b67db3336dbe5e853f86b1d230eb20
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Thu Oct 31 09:36:49 2024 +0000

    chore(ci): update actionlint

    Fixes #38

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit f332076505ae3e52c890883ad21d8fd842c8a427
Merge: 472bdbd d550dcf
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed Oct 30 11:58:03 2024 +0900

    Merge pull request #37 from ianlewis/dependabot/npm_and_yarn/node-22.11.0

    Bump node from 20.16.0 to 22.11.0

commit 472bdbd15d159a133a154fc3fedc9966cf4f78d3
Merge: 9fb30df 922062b
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed Oct 30 11:57:51 2024 +0900

    Merge pull request #36 from ianlewis/dependabot/github_actions/actions/setup-node-4.1.0

    Bump actions/setup-node from 4.0.3 to 4.1.0

commit d550dcf388895dfd00c71252b8a4f42897fce09e
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed Oct 30 02:57:31 2024 +0000

    Bump node from 20.16.0 to 22.11.0

    Bumps [node](https://github.com/aredridel/node-bin-gen) from 20.16.0 to 22.11.0.
    - [Commits](https://github.com/aredridel/node-bin-gen/commits)

    ---
    updated-dependencies:
    - dependency-name: node dependency-type: direct:development update-type: version-update:semver-major ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 922062b22c14d1a18e46615d46df7b3a03cb4950
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed Oct 30 02:57:15 2024 +0000

    Bump actions/setup-node from 4.0.3 to 4.1.0

    Bumps [actions/setup-node](https://github.com/actions/setup-node) from 4.0.3 to 4.1.0.
    - [Release notes](https://github.com/actions/setup-node/releases)
    - [Commits](https://github.com/actions/setup-node/compare/1e60f620b9541d16bece96c5465dc8ee9832be0b...39370e3970a6d050c480ffad4ff0ed4d3fdee5af)

    ---
    updated-dependencies:
    - dependency-name: actions/setup-node dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 9fb30dffc1c093c57994e919dde11e0395e1c6d6
Merge: 0e19563 52cf1fb
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed Oct 30 11:56:44 2024 +0900

    Merge pull request #30 from ianlewis/dependabot/github_actions/ianlewis/todo-issue-reopener-1.3.0

    Bump ianlewis/todo-issue-reopener from 1.2.1 to 1.3.0

commit 0e19563942a23d0f334c41c2102674f65815a63e
Merge: 621efc2 fbc5ba2
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed Oct 30 11:56:22 2024 +0900

    Merge pull request #33 from ianlewis/dependabot/github_actions/actions/checkout-4.2.0

    Bump actions/checkout from 4.1.7 to 4.2.0

commit 621efc2532058f710158f0c3c965dfa75700a2ef
Merge: a5b60fd 3660dcb
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed Oct 30 11:56:04 2024 +0900

    Merge pull request #35 from ianlewis/dependabot/npm_and_yarn/markdownlint-cli-0.42.0

    Bump markdownlint-cli from 0.41.0 to 0.42.0

commit 3660dcbe9916bb438cd30b760acff1319472ca0f
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Oct 1 16:54:44 2024 +0000

    Bump markdownlint-cli from 0.41.0 to 0.42.0

    Bumps [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) from 0.41.0 to 0.42.0.
    - [Release notes](https://github.com/igorshubovych/markdownlint-cli/releases)
    - [Commits](https://github.com/igorshubovych/markdownlint-cli/compare/v0.41.0...v0.42.0)

    ---
    updated-dependencies:
    - dependency-name: markdownlint-cli dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit fbc5ba23a48169ecafdb3f24b68e9cd5e0381d65
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Oct 1 16:40:00 2024 +0000

    Bump actions/checkout from 4.1.7 to 4.2.0

    Bumps [actions/checkout](https://github.com/actions/checkout) from 4.1.7 to 4.2.0.
    - [Release notes](https://github.com/actions/checkout/releases)
    - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/actions/checkout/compare/692973e3d937129bcbf40652eb9f2f61becf3332...d632683dd7b4114ad314bca15554477dd762a938)

    ---
    updated-dependencies:
    - dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 52cf1fbd60974e9de2dfbee2244b3d068fe92d64
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sun Sep 1 16:50:44 2024 +0000

    Bump ianlewis/todo-issue-reopener from 1.2.1 to 1.3.0

    Bumps [ianlewis/todo-issue-reopener](https://github.com/ianlewis/todo-issue-reopener) from 1.2.1 to 1.3.0.
    - [Release notes](https://github.com/ianlewis/todo-issue-reopener/releases)
    - [Changelog](https://github.com/ianlewis/todo-issue-reopener/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/ianlewis/todo-issue-reopener/compare/339a05bfcc934adf6aa425b968a2d2f2af4f12ad...9adf81abbaeceed8d6c90c106cc2a965797963cf)

    ---
    updated-dependencies:
    - dependency-name: ianlewis/todo-issue-reopener dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit a5b60fd799556254b2b27edaea622a300e4bcf13
Merge: 980a139 5c3bba0
Author: Ian Lewis <ianlewis@google.com>
Date:   Tue Aug 13 10:02:47 2024 +0900

    Merge pull request #28 from ianlewis/dependabot/npm_and_yarn/prettier-3.3.3

    Bump prettier from 3.2.5 to 3.3.3

commit 980a139f82d7fe2fb1b27f139e712dd9f53a52bd
Merge: c070990 d0d9bf3
Author: Ian Lewis <ianlewis@google.com>
Date:   Tue Aug 13 10:02:32 2024 +0900

    Merge pull request #29 from ianlewis/dependabot/github_actions/actions/setup-node-4.0.3

    Bump actions/setup-node from 4.0.2 to 4.0.3

commit 5c3bba04336611cf65baf2800133895d7efa02de
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Aug 13 01:02:23 2024 +0000

    Bump prettier from 3.2.5 to 3.3.3

    Bumps [prettier](https://github.com/prettier/prettier) from 3.2.5 to 3.3.3.
    - [Release notes](https://github.com/prettier/prettier/releases)
    - [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/prettier/prettier/compare/3.2.5...3.3.3)

    ---
    updated-dependencies:
    - dependency-name: prettier dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit d0d9bf36003e72a5afd49c4f2cfbf30d3f6969aa
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Aug 13 01:02:00 2024 +0000

    Bump actions/setup-node from 4.0.2 to 4.0.3

    Bumps [actions/setup-node](https://github.com/actions/setup-node) from 4.0.2 to 4.0.3.
    - [Release notes](https://github.com/actions/setup-node/releases)
    - [Commits](https://github.com/actions/setup-node/compare/60edb5dd545a775178f52524783378180af0d1f8...1e60f620b9541d16bece96c5465dc8ee9832be0b)

    ---
    updated-dependencies:
    - dependency-name: actions/setup-node dependency-type: direct:production update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit c070990118a8be27a2f063209fa6e57feb686f05
Merge: d7f1d93 79382ea
Author: Ian Lewis <ianlewis@google.com>
Date:   Tue Aug 13 10:01:18 2024 +0900

    Merge pull request #27 from ianlewis/dependabot/npm_and_yarn/node-20.16.0

    Bump node from 20.14.0 to 20.16.0

commit d7f1d9318f6759f59fbb9e588906c4dfb6821ced
Merge: 4819f46 97de7b5
Author: Ian Lewis <ianlewis@google.com>
Date:   Tue Aug 13 10:01:07 2024 +0900

    Merge pull request #24 from ianlewis/dependabot/github_actions/actions/checkout-4.1.7

    Bump actions/checkout from 4.1.6 to 4.1.7

commit 79382ea5c54f89edc87dfc50fd6ec1d3e8dc6dd3
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Thu Aug 1 16:19:58 2024 +0000

    Bump node from 20.14.0 to 20.16.0

    Bumps [node](https://github.com/aredridel/node-bin-gen) from 20.14.0 to 20.16.0.
    - [Commits](https://github.com/aredridel/node-bin-gen/commits)

    ---
    updated-dependencies:
    - dependency-name: node dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 97de7b5424754acb7db802687913990c8a86d760
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Jul 1 16:28:14 2024 +0000

    Bump actions/checkout from 4.1.6 to 4.1.7

    Bumps [actions/checkout](https://github.com/actions/checkout) from 4.1.6 to 4.1.7.
    - [Release notes](https://github.com/actions/checkout/releases)
    - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/actions/checkout/compare/a5ac7e51b41094c92402da3b24376905380afc29...692973e3d937129bcbf40652eb9f2f61becf3332)

    ---
    updated-dependencies:
    - dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 4819f462738c2b4e70a66de47456eb9b6c8c3da6
Merge: 05cd6e8 0af5651
Author: Ian Lewis <ianlewis@google.com>
Date:   Sun Jun 2 12:40:13 2024 +0900

    Merge pull request #20 from ianlewis/dependabot/npm_and_yarn/node-20.14.0

    Bump node from 20.13.0 to 20.14.0

commit 0af5651ce507ba5cd04a6b09cff6a77aebd0f5f5
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sun Jun 2 03:40:07 2024 +0000

    Bump node from 20.13.0 to 20.14.0

    Bumps [node](https://github.com/aredridel/node-bin-gen) from 20.13.0 to 20.14.0.
    - [Commits](https://github.com/aredridel/node-bin-gen/commits)

    ---
    updated-dependencies:
    - dependency-name: node dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 05cd6e8a1d13afdfd9c09fa5df0b78e791638603
Merge: d3021db fcff1d7
Author: Ian Lewis <ianlewis@google.com>
Date:   Sun Jun 2 12:39:57 2024 +0900

    Merge pull request #18 from ianlewis/dependabot/github_actions/ianlewis/todo-issue-reopener-1.2.1

    Bump ianlewis/todo-issue-reopener from 1.2.0 to 1.2.1

commit d3021db122f941ba8968324a657de23aca4302fd
Merge: d9287e1 86254d1
Author: Ian Lewis <ianlewis@google.com>
Date:   Sun Jun 2 12:39:48 2024 +0900

    Merge pull request #19 from ianlewis/dependabot/github_actions/actions/checkout-4.1.6

    Bump actions/checkout from 4.1.5 to 4.1.6

commit d9287e16d2d60024892ac983439ef849ee8ac170
Merge: 6e2d5b0 f6e35c2
Author: Ian Lewis <ianlewis@google.com>
Date:   Sun Jun 2 12:39:29 2024 +0900

    Merge pull request #21 from ianlewis/dependabot/npm_and_yarn/markdownlint-cli-0.41.0

    Bump markdownlint-cli from 0.40.0 to 0.41.0

commit f6e35c2329427aa54b34c0c71c395c2cdfae0d8f
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sat Jun 1 16:57:38 2024 +0000

    Bump markdownlint-cli from 0.40.0 to 0.41.0

    Bumps [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) from 0.40.0 to 0.41.0.
    - [Release notes](https://github.com/igorshubovych/markdownlint-cli/releases)
    - [Commits](https://github.com/igorshubovych/markdownlint-cli/compare/v0.40.0...v0.41.0)

    ---
    updated-dependencies:
    - dependency-name: markdownlint-cli dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 86254d14b504853b789f4aa664970f0e64beb62d
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sat Jun 1 16:47:22 2024 +0000

    Bump actions/checkout from 4.1.5 to 4.1.6

    Bumps [actions/checkout](https://github.com/actions/checkout) from 4.1.5 to 4.1.6.
    - [Release notes](https://github.com/actions/checkout/releases)
    - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/actions/checkout/compare/44c2b7a8a4ea60a981eaca3cf939b5f4305c123b...a5ac7e51b41094c92402da3b24376905380afc29)

    ---
    updated-dependencies:
    - dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit fcff1d7245be2b1c89762666eeb3b961e062c00b
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sat Jun 1 16:47:19 2024 +0000

    Bump ianlewis/todo-issue-reopener from 1.2.0 to 1.2.1

    Bumps [ianlewis/todo-issue-reopener](https://github.com/ianlewis/todo-issue-reopener) from 1.2.0 to 1.2.1.
    - [Release notes](https://github.com/ianlewis/todo-issue-reopener/releases)
    - [Changelog](https://github.com/ianlewis/todo-issue-reopener/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/ianlewis/todo-issue-reopener/compare/8727d6c42adc4085ffb838abcfe92e646c1f40bd...339a05bfcc934adf6aa425b968a2d2f2af4f12ad)

    ---
    updated-dependencies:
    - dependency-name: ianlewis/todo-issue-reopener dependency-type: direct:production update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 6e2d5b01780421df7ebf0647a37c2ede717e454e
Merge: 11d368b 73a58e3
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed May 8 10:32:19 2024 +0900

    Merge pull request #17 from ianlewis/dependabot/npm_and_yarn/markdownlint-cli-0.40.0

    Bump markdownlint-cli from 0.38.0 to 0.40.0

commit 73a58e36a4e15a46beb4198fec62e61f53de5a29
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed May 8 01:31:44 2024 +0000

    Bump markdownlint-cli from 0.38.0 to 0.40.0

    Bumps [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) from 0.38.0 to 0.40.0.
    - [Release notes](https://github.com/igorshubovych/markdownlint-cli/releases)
    - [Commits](https://github.com/igorshubovych/markdownlint-cli/compare/v0.38.0...v0.40.0)

    ---
    updated-dependencies:
    - dependency-name: markdownlint-cli dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 11d368bc1756d83e917d77f5942eff4fb1887cd5
Merge: 7fbe102 5558178
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed May 8 10:31:00 2024 +0900

    Merge pull request #16 from ianlewis/dependabot/github_actions/actions/checkout-4.1.5

    Bump actions/checkout from 4.1.1 to 4.1.5

commit 7fbe10289dea13347ce7c237477cb40fb9f8faf2
Merge: 164e104 0bdd45a
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed May 8 10:30:47 2024 +0900

    Merge pull request #11 from ianlewis/dependabot/npm_and_yarn/prettier-3.2.5

    Bump prettier from 3.1.1 to 3.2.5

commit 5558178e7c2317a62f8bbd44a2e195d74f44603e
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed May 8 01:30:23 2024 +0000

    Bump actions/checkout from 4.1.1 to 4.1.5

    Bumps [actions/checkout](https://github.com/actions/checkout) from 4.1.1 to 4.1.5.
    - [Release notes](https://github.com/actions/checkout/releases)
    - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/actions/checkout/compare/b4ffde65f46336ab88eb53be808477a3936bae11...44c2b7a8a4ea60a981eaca3cf939b5f4305c123b)

    ---
    updated-dependencies:
    - dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 0bdd45ae8925779784f5162fa0cc5038e8b13d83
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed May 8 01:30:23 2024 +0000

    Bump prettier from 3.1.1 to 3.2.5

    Bumps [prettier](https://github.com/prettier/prettier) from 3.1.1 to 3.2.5.
    - [Release notes](https://github.com/prettier/prettier/releases)
    - [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/prettier/prettier/compare/3.1.1...3.2.5)

    ---
    updated-dependencies:
    - dependency-name: prettier dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 164e1047abe0962501bbe1cf34d8b6141ceacc3d
Merge: 59f143b 40e3287
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed May 8 10:30:14 2024 +0900

    Merge pull request #10 from ianlewis/dependabot/pip/yamllint-1.35.1

    Bump yamllint from 1.33.0 to 1.35.1

commit 59f143b1eec5dd9a26199108955877cda8c9b183
Merge: 72ef22a dcb3241
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed May 8 10:29:44 2024 +0900

    Merge pull request #12 from ianlewis/dependabot/github_actions/actions/setup-node-4.0.2

    Bump actions/setup-node from 4.0.1 to 4.0.2

commit 72ef22a4d9afa6c7b948679082666af5fef19581
Merge: 524a025 ed8d2d8
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed May 8 10:28:16 2024 +0900

    Merge pull request #15 from ianlewis/update-versions

    Update versions

commit ed8d2d8e5bcdb3079eb055b99187d867144da4e1
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Wed May 8 01:27:42 2024 +0000

    Fix actionlint checksum

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit a9cf7eb7564d0291719441ddc82797d0dc9abc71
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Wed May 8 01:24:56 2024 +0000

    Update package-lock.json

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 0a3f9ae6620d49cd1dd5c743ebcfdda2eb6b20f4
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Wed May 8 01:22:33 2024 +0000

    Update versions

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 524a025152da58b6ed4265cd62c8d6a3ce920ba9
Merge: 934d716 4adaf96
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed May 8 10:17:44 2024 +0900

    Merge pull request #14 from ianlewis/7-ci-use-ianlewistodo-issue-reopener

    Add todo-issue-reopener workflow.

commit 4adaf96dc545f6f2509ef65debe358e7afb251a2
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Wed May 8 01:07:25 2024 +0000

    Add todo-issue-reopener workflow.

    Fixes #7

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit dcb32414344cf99a6076f00640f9b532812d6f17
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri Mar 1 16:53:06 2024 +0000

    Bump actions/setup-node from 4.0.1 to 4.0.2

    Bumps [actions/setup-node](https://github.com/actions/setup-node) from 4.0.1 to 4.0.2.
    - [Release notes](https://github.com/actions/setup-node/releases)
    - [Commits](https://github.com/actions/setup-node/compare/b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8...60edb5dd545a775178f52524783378180af0d1f8)

    ---
    updated-dependencies:
    - dependency-name: actions/setup-node dependency-type: direct:production update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 40e3287a8ffd968533d41cef4beaaad7d205ecef
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri Mar 1 16:04:07 2024 +0000

    Bump yamllint from 1.33.0 to 1.35.1

    Bumps [yamllint](https://github.com/adrienverge/yamllint) from 1.33.0 to 1.35.1.
    - [Changelog](https://github.com/adrienverge/yamllint/blob/master/CHANGELOG.rst)
    - [Commits](https://github.com/adrienverge/yamllint/compare/v1.33.0...v1.35.1)

    ---
    updated-dependencies:
    - dependency-name: yamllint dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 934d716f56fa562494e02fe78c695adcca26f571
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Tue Feb 6 03:56:04 2024 +0000

    refactor: use git ls-files in Makefile

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit e92f7d3a17e9b5f690880d805ee938343cec6908
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Wed Jan 17 01:34:18 2024 +0000

    Add badge

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit 38c910015ef4a2802b6d45af590b33b501df7181
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Wed Jan 17 01:33:24 2024 +0000

    Add license header

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit c4bcdc1044929d7d5d38db692a12da002b367905
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Wed Jan 17 01:32:11 2024 +0000

    Add stale issue workflow

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit acf5c12dbfdb68b9307a9e5f34ab10033a24af54
Merge: 54a55c5 7d464fd
Author: Ian Lewis <ianlewis@google.com>
Date:   Wed Jan 10 10:14:00 2024 +0900

    Merge pull request #3 from ianlewis/dependabot/npm_and_yarn/prettier-3.1.1

    Bump prettier from 3.0.3 to 3.1.1

commit 7d464fd1182abcae2c8acec525eb5e7e95b75ad4
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sat Jan 6 22:18:10 2024 +0000

    Bump prettier from 3.0.3 to 3.1.1

    Bumps [prettier](https://github.com/prettier/prettier) from 3.0.3 to 3.1.1.
    - [Release notes](https://github.com/prettier/prettier/releases)
    - [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/prettier/prettier/compare/3.0.3...3.1.1)

    ---
    updated-dependencies:
    - dependency-name: prettier dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 54a55c56e95117d7c38335e09fb912edafb2937e
Merge: b281536 0fba42a
Author: Ian Lewis <ianlewis@google.com>
Date:   Sun Jan 7 07:18:02 2024 +0900

    Merge pull request #2 from ianlewis/dependabot/pip/yamllint-1.33.0

    Bump yamllint from 1.32.0 to 1.33.0

commit b281536b855e6721443320082b46c1a49041fed3
Merge: 4cd51b3 c36315b
Author: Ian Lewis <ianlewis@google.com>
Date:   Sun Jan 7 07:17:19 2024 +0900

    Merge pull request #4 from ianlewis/dependabot/npm_and_yarn/markdownlint-cli-0.38.0

    Bump markdownlint-cli from 0.37.0 to 0.38.0

commit 4cd51b3ed27c3a4fcad40e75fdc65f9352746636
Merge: cc05510 6baca37
Author: Ian Lewis <ianlewis@google.com>
Date:   Sun Jan 7 07:16:59 2024 +0900

    Merge pull request #5 from ianlewis/dependabot/github_actions/actions/setup-node-4.0.1

    Bump actions/setup-node from 4.0.0 to 4.0.1

commit cc05510b8b50a40876c4362851349e5ca28ae6b8
Merge: 528d58f 1b38c9e
Author: Ian Lewis <ianlewis@google.com>
Date:   Sun Jan 7 07:16:38 2024 +0900

    Merge pull request #6 from ianlewis/dependabot/pip/pathspec-0.12.1

    Bump pathspec from 0.11.2 to 0.12.1

commit 1b38c9e7ed3bc921b21199bd448cd5fe54d7c2e3
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Jan 1 16:35:41 2024 +0000

    Bump pathspec from 0.11.2 to 0.12.1

    Bumps [pathspec](https://github.com/cpburnz/python-pathspec) from 0.11.2 to 0.12.1.
    - [Release notes](https://github.com/cpburnz/python-pathspec/releases)
    - [Changelog](https://github.com/cpburnz/python-pathspec/blob/master/CHANGES.rst)
    - [Commits](https://github.com/cpburnz/python-pathspec/compare/v0.11.2...v0.12.1)

    ---
    updated-dependencies:
    - dependency-name: pathspec dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 6baca37beda9f4c5df666d4f2700cc3a0cd3bdad
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Jan 1 16:06:18 2024 +0000

    Bump actions/setup-node from 4.0.0 to 4.0.1

    Bumps [actions/setup-node](https://github.com/actions/setup-node) from 4.0.0 to 4.0.1.
    - [Release notes](https://github.com/actions/setup-node/releases)
    - [Commits](https://github.com/actions/setup-node/compare/8f152de45cc393bb48ce5d89d36b731f54556e65...b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8)

    ---
    updated-dependencies:
    - dependency-name: actions/setup-node dependency-type: direct:production update-type: version-update:semver-patch ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit c36315b816a333fa7f43d772d2d0e3f6f1bcf8f0
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Jan 1 16:05:00 2024 +0000

    Bump markdownlint-cli from 0.37.0 to 0.38.0

    Bumps [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) from 0.37.0 to 0.38.0.
    - [Release notes](https://github.com/igorshubovych/markdownlint-cli/releases)
    - [Commits](https://github.com/igorshubovych/markdownlint-cli/compare/v0.37.0...v0.38.0)

    ---
    updated-dependencies:
    - dependency-name: markdownlint-cli dependency-type: direct:development update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 0fba42a5f93c6ecfc7cc86850ada5665e450ceff
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Nov 13 04:58:04 2023 +0000

    Bump yamllint from 1.32.0 to 1.33.0

    Bumps [yamllint](https://github.com/adrienverge/yamllint) from 1.32.0 to 1.33.0.
    - [Changelog](https://github.com/adrienverge/yamllint/blob/master/CHANGELOG.rst)
    - [Commits](https://github.com/adrienverge/yamllint/compare/v1.32.0...v1.33.0)

    ---
    updated-dependencies:
    - dependency-name: yamllint dependency-type: direct:production update-type: version-update:semver-minor ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 528d58f47d76cdf538a312c4eab846f5531e5633
Author: Ian Lewis <ianmlewis@gmail.com>
Date:   Mon Nov 13 04:57:32 2023 +0000

    Add base files

    Signed-off-by: Ian Lewis <ianmlewis@gmail.com>

commit bbe40684d5e1a9557d81d169b1f467b6eda5eee2
Author: Ian Lewis <ianlewis@google.com>
Date:   Mon Nov 13 13:50:40 2023 +0900

    Initial commit

**Related Issues:**

N/A

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
