### PR TITLE
fix: create Transformers on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The index now supports whitespace and punctuation folding ([#25](https://github.com/ianlewis/go-stardict/issues/25))
-- The synonym index (.syn) file is now supported ([#2](https://github.com/ianlewis/go-stardict/issues/2))
-- `Stardict.Search` and `Idx.Search` now support queries in glob format ([#21](https://github.com/ianlewis/go-stardict/issues/21))
+- The index now supports whitespace and punctuation folding ([#25](https://github.com/ianlewis/go-stardict/issues/25)).
+- The synonym index (.syn) file is now supported ([#2](https://github.com/ianlewis/go-stardict/issues/2)).
+- `Stardict.Search` and `Idx.Search` now support queries in glob format ([#21](https://github.com/ianlewis/go-stardict/issues/21)).
 
 ### Changed
 
 - The minimum supported Go version is now 1.23.
+- `stardict.Open` and `stardict.OpenAll` now take an `options` argument which allows for specifying options for opening dictionaries ([#87](https://github.com/ianlewis/go-stardict/issues/87)).
+- `stardict.idx.Options.Folder` is now a constructor `func() transform.Transformer` rather than a static `golang.org/x/text/transform.Transformer` value ([#87](https://github.com/ianlewis/go-stardict/issues/87)).
 
 ## [0.1.0] - 2024-11-04
 

--- a/idx/idx_test.go
+++ b/idx/idx_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/text/cases"
+	"golang.org/x/text/transform"
 
 	"github.com/ianlewis/go-stardict/idx"
 	"github.com/ianlewis/go-stardict/internal/testutil"
@@ -222,7 +223,9 @@ func TestIdx_Search(t *testing.T) {
 			},
 			idxoffsetbits: 32,
 			options: &idx.Options{
-				Folder: cases.Fold(),
+				Folder: func() transform.Transformer {
+					return cases.Fold()
+				},
 			},
 
 			expected: []*idx.Word{
@@ -261,7 +264,9 @@ func TestIdx_Search(t *testing.T) {
 			},
 			idxoffsetbits: 32,
 			options: &idx.Options{
-				Folder: cases.Fold(),
+				Folder: func() transform.Transformer {
+					return cases.Fold()
+				},
 			},
 
 			// NOTE: The returned index word is the value in the index
@@ -300,7 +305,9 @@ func TestIdx_Search(t *testing.T) {
 			},
 			idxoffsetbits: 32,
 			options: &idx.Options{
-				Folder: cases.Fold(),
+				Folder: func() transform.Transformer {
+					return cases.Fold()
+				},
 			},
 
 			expected: nil,
@@ -331,7 +338,9 @@ func TestIdx_Search(t *testing.T) {
 			},
 			idxoffsetbits: 32,
 			options: &idx.Options{
-				Folder: cases.Fold(),
+				Folder: func() transform.Transformer {
+					return cases.Fold()
+				},
 			},
 
 			expected: nil,


### PR DESCRIPTION
**Description:**

Create the folding `Transformer` via a constructor on demand. A `Transformer` can hold state so it can't always be reused. It must be re-created each use.

**Related Issues:**

Fixes #87 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
